### PR TITLE
attempt to reduce structures

### DIFF
--- a/gc/values/value.go
+++ b/gc/values/value.go
@@ -28,6 +28,8 @@ type Value interface {
 	Type() Type
 
 	Copy() Value
+
+	IsZero() bool
 }
 
 type value struct {
@@ -113,6 +115,10 @@ func (v *value) Copy() Value {
 	return value
 }
 
+func (v *value) IsZero() bool {
+	return v.Real() == 0 && v.Imag() == 0
+}
+
 // NewValue returns the 0 real value
 func NewValue() Value {
 	value := new(value)
@@ -121,6 +127,9 @@ func NewValue() Value {
 
 // MakeValue returns a Value with value val
 func MakeValue(val interface{}) Value {
+	if _, ok := val.(Value); ok {
+		return val.(Value)
+	}
 	value := new(value)
 	value.Set(val)
 	return value

--- a/gc/values/value_test.go
+++ b/gc/values/value_test.go
@@ -181,13 +181,21 @@ func TestComplex(t *testing.T) {
 	}
 }
 
-func TestMakeValuesAndValues(t *testing.T) {
+func TestMakeValuesNewValuesAndValues(t *testing.T) {
 	testValueA := MakeValue(0.5)
-	testValueB := MakeValue(0.6)
-	testValues := MakeValues(testValueA, testValueB)
+	testValueB := MakeValue(0.6+0.4i)
+	testValueC := NewValue()
+	testValuesA := MakeValues(testValueA, testValueB, testValueC)
 
-	if !reflect.DeepEqual(testValues.Values()[0], testValueA) || !reflect.DeepEqual(testValues.Values()[1], testValueB) {
+	if !reflect.DeepEqual(RetrieveValues(testValuesA)[0], testValueA) || !reflect.DeepEqual(testValuesA.values()[1], testValueB) || testValuesA.values()[2] != nil {
 		t.Fail()
+	}
+
+	testValuesB := NewValues(3)
+	for i := 0; i < testValuesB.Len(); i++ {
+		if !reflect.DeepEqual(testValuesB.Get(i), NewValue()) {
+			t.Fail()
+		}
 	}
 }
 
@@ -264,15 +272,15 @@ func TestAppendValue(t *testing.T) {
 	testValueC := MakeValue(0.7)
 	testValuesA.Append(testValueC)
 
-	if !reflect.DeepEqual(testValuesA.Values()[2], testValueC) {
+	if !reflect.DeepEqual(testValuesA.values()[2], testValueC) {
 		t.Fail()
 	}
 
 	testValuesB := MakeValues()
 	testValuesB.Append(testValueC)
 
-	if !reflect.DeepEqual(testValuesB.Values()[0], testValueC) {
-		t.Errorf("Expected %v, received %v", testValueC, testValuesB.Values()[0])
+	if !reflect.DeepEqual(testValuesB.values()[0], testValueC) {
+		t.Errorf("Expected %v, received %v", testValueC, testValuesB.values()[0])
 	}
 }
 
@@ -288,7 +296,7 @@ func TestSubsetAndLenValues(t *testing.T) {
 
 	lenB := testValues.Len()
 
-	if !reflect.DeepEqual(testValues.Values()[0], testValueB) || !reflect.DeepEqual(testValues.Values()[1], testValueC) {
+	if !reflect.DeepEqual(testValues.values()[0], testValueB) || !reflect.DeepEqual(testValues.values()[1], testValueC) {
 		t.Fail()
 	}
 

--- a/gc/vectors/vector.go
+++ b/gc/vectors/vector.go
@@ -136,12 +136,7 @@ func NewVector(space Space, length int) Vector {
 	vector := new(vector)
 	vector.space = space
 	vector.coreType = gcv.Real
-	elements := make([]interface{}, length)
-	for index := range elements {
-		val := gcv.NewValue()
-		elements[index] = val
-	}
-	vector.elements = gcv.MakeValues(elements...)
+	vector.elements = gcv.NewValues(length)
 	return vector
 }
 

--- a/gc/vectors/vector_test.go
+++ b/gc/vectors/vector_test.go
@@ -125,6 +125,17 @@ func TestMakeNewTransVector(t *testing.T) {
 	}
 }
 
+func TestMakeNewConjVector(t *testing.T) {
+	testVectorA := NewVector(RowSpace, 4)
+	testTransVectorA := MakeConjVector(testVectorA)
+
+	testVectorA.Conj()
+
+	if !reflect.DeepEqual(testVectorA, testTransVectorA) {
+		t.Errorf("Expected %v, received %v", true, reflect.DeepEqual(testVectorA, testTransVectorA))
+	}
+}
+
 func TestMakeNewConjTransVector(t *testing.T) {
 	testVectorA := NewVector(RowSpace, 4)
 	testTransVectorA := MakeConjTransVector(testVectorA)

--- a/gc/vectors/vectors.go
+++ b/gc/vectors/vectors.go
@@ -98,7 +98,7 @@ func (v *vectors) SetValue(i int, j int, value gcv.Value) {
 	}
 	vector := v.vects[i]
 	values := vector.Elements()
-	values.Values()[j] = value
+	values.Set(j, value)
 }
 
 func (v *vectors) Append(vect Vector) {
@@ -129,7 +129,7 @@ func (v *vectors) Subset(start, finish int) Vectors {
 
 func (v *vectors) IndexOf(vect Vector) int {
 	found := false
-	values := vect.Elements().Values()
+	values := gcv.RetrieveValues(vect.Elements())
 	for index, vector := range v.Vectors() {
 		if vect.Len() != vector.Len() {
 			continue


### PR DESCRIPTION
there is no reason to keep zero Value structs around. They could eat up
a lot of memory as the length of Vector grows or the Dim of a Matrix
increases. This is the first of more PRs to follow. Better encapsulation
by restricting access to certain underline data structs
  